### PR TITLE
Enabled the plugin to use a specific version of google play services

### DIFF
--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -38,3 +38,7 @@ dependencies {
         transitive = true
     }
 }
+
+project.ext {
+     googlePlayServicesVersion = "10.2.6"
+ }

--- a/plugin/platforms/android/include.gradle
+++ b/plugin/platforms/android/include.gradle
@@ -24,8 +24,9 @@ repositories {
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '8.4.0'
+    compile "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
     compile 'com.facebook.android:facebook-android-sdk:4.6.0'
-    compile 'com.google.android.gms:play-services-auth:8.4.0'
 
     compile('com.twitter.sdk.android:twitter:1.13.2@aar') {
         transitive = true


### PR DESCRIPTION
The plugin currently, uses a fixed version of google play services (8.4.0) which causes some conflicts with other plugins such as firebase that requires a version post 10.0.0. A solution adopted to other plugins is to allow the usage of a custom version using variables in gradle ([nativescript-plugin-firebase implementation](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/blob/master/platforms/android/include.gradle#L25))

This feature will also solve: https://github.com/mkloubert/nativescript-social-login/issues/13
