### PR TITLE
Correct the import statement in typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ if (application.ios) {
 Include the module in your code-behind:
 
 ```typescript
-import SocialLogin = require("nativescript-social-login");
+import * as SocialLogin from 'nativescript-social-login';
 ```
 
 ### Initialize


### PR DESCRIPTION
In order to build with `aot` flag, the import statement must be changed.