### PR TITLE
Change idToken to accessToken

### DIFF
--- a/src/SocialLogin.ios.ts
+++ b/src/SocialLogin.ios.ts
@@ -266,7 +266,7 @@ export class SocialLogin extends Social {
                             photo: user.profile.imageURLWithDimension(100),
                             authCode: user.serverAuthCode
                                 ? user.serverAuthCode
-                                : user.authentication.idToken,
+                                : user.authentication.accessToken,
                             id: user.userID
                         }; // Safe to send to the server // For client-side use only!
 


### PR DESCRIPTION
When not using serverClientId, callback should return the "user.authentication.accessToken" instead of "user.authentication.idToken", which cannot be used as a valid credential to fetch the user details.